### PR TITLE
Extract Slack webhook values to config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11.3-alpine3.8 AS build
-COPY . /go/src/app
+COPY . /go/src/github.com/jpweber/cole
 
-WORKDIR /go/src/app
+WORKDIR /go/src/github.com/jpweber/cole
 RUN apk --update upgrade && \
     apk add ca-certificates && \
     update-ca-certificates && \
@@ -15,5 +15,5 @@ RUN apk --update upgrade && \
     apk add ca-certificates && \
     update-ca-certificates && \
     rm -rf /var/cache/apk/*
-COPY --from=build /go/src/app/app /cole
+COPY --from=build /go/src/github.com/jpweber/cole/app /cole
 CMD ["/cole"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ There is a forthcoming blog post on [jpweber.io](http://jpweber.io/blog
 # Interval = 10
 # HTTPEndpoint = "https://hooks.slack.com/services/..."
 # HTTPMethod = "POST"
+# SlackChannel = "#general"
+# SlackUsername = "Cole - DeadManSwitch Monitor"
+# SlackIcon = ":monkey_face:"
 
 
 # PagerDuty
@@ -83,6 +86,9 @@ PDIntegrationKey = "5353fb993888441811111111111"
 * `HTTP_METHOD`
 * `EMAIL_ADDR`
 * `PD_KEY`
+* `SLACK_CHANNEL`
+* `SLACK_USERNAME`
+* `SLACK_ICON`
 
 ## Example Prometheus Alert Manager config
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -14,6 +14,9 @@ type Conf struct {
 	HTTPMethod       string `env:"HTTP_METHOD" envDefault:"POST"`
 	EmailAddress     string `env:"EMAIL_ADDR"`
 	PDIntegrationKey string `env:"PD_KEY"`
+	SlackChannel     string `env:"SLACK_CHANNEL" envDefault:"#general"`
+	SlackUsername    string `env:"SLACK_USERNAME" envDefault:"Cole - DeadManSwitch Monitor"`
+	SlackIcon        string `env:"SLACK_ICON" envDefault:":monkey_face:"`
 }
 
 // Reads info from config file

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -79,9 +79,9 @@ func (n *NotificationSet) slack() {
 	log.Println("slack method")
 	payload := slack.Payload{
 		Text:      "Missed DeadManSwitch Alert  - " + n.Message.CommonAnnotations["message"],
-		Username:  "Cole - DeadManSwitch Monitor",
-		Channel:   "#general",
-		IconEmoji: ":monkey_face:",
+		Username:  n.Config.SlackUsername,
+		Channel:   n.Config.SlackChannel,
+		IconEmoji: n.Config.SlackIcon,
 	}
 	jsonBody, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
Currently, several Slack webhook options are hardcoded (ie., Cole always posts to the `#general` channel).

This PR extracts a few Slack options to allow them to be set via config file/environment variable.