### PR TITLE
Fix docker build, include tls.Config in http.Server

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
-	"crypto/tls"
 
 	"github.com/caarlos0/env"
 	"github.com/jpweber/cole/configuration"
@@ -95,19 +95,19 @@ func main() {
 	// Server Lifecycle
 	//To setup a insecure server for http without any tls validation
 	/*
-	s := &http.Server{
-		Addr:         ":8080",
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-	}
-	go func() {
-		log.Fatal(s.ListenAndServe())
-	}()
+		s := &http.Server{
+			Addr:         ":8080",
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		go func() {
+			log.Fatal(s.ListenAndServe())
+		}()
 	*/
 
 	//To setup a https secure server with certificate validation.
-        //To setup a https secure server with TLS 1.2
-         cfg := &tls.Config{
+	//To setup a https secure server with TLS 1.2
+	cfg := &tls.Config{
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
@@ -118,17 +118,16 @@ func main() {
 		},
 	}
 
-
 	s := &http.Server{
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
+		TLSConfig:    cfg,
 	}
-	#err := http.ListenAndServeTLS(":443", "/usr/local/share/ca-certificates/https-server.crt", "/usr/local/share/ca-certificates/https-server.key", nil);
-	err  := s.ListenAndServeTLS("/usr/local/share/ca-certificates/https-server.crt", "/usr/local/share/ca-certificates/https-server.key");
+	err := s.ListenAndServeTLS("/usr/local/share/ca-certificates/https-server.crt", "/usr/local/share/ca-certificates/https-server.key")
 
 	if err != nil {
-	    log.Fatal(err)
-	 }
+		log.Fatal(err)
+	}
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
When merged this pull request will:
- Fix error in local docker build
```
$ git clone https://github.com/jpweber/cole.git
$ cd cole
$ docker build -t cole .
---------- SNIP --------------
Step 6/12 : RUN CGO_ENABLED=0 go build -a -ldflags '-s' -installsuffix cgo -o app .
 ---> Running in 92fe8e2f38e9
# github.com/jpweber/cole
./main.go:126:2: invalid character U+0023 '#'
./main.go:127:7: no new variables on left side of :=
The command '/bin/sh -c CGO_ENABLED=0 go build -a -ldflags '-s' -installsuffix cgo -o app .' returned a non-zero code: 2
```
- Include defined tls.Config in http.Server

Resolves #11 